### PR TITLE
Bugfix so that last frame is included.

### DIFF
--- a/sphviewer/tools/camera_tools.py
+++ b/sphviewer/tools/camera_tools.py
@@ -76,7 +76,7 @@ def get_camera_trajectory(targets, anchors):
             f_interp[key] = interp.interp1d(frames, anchors[key])
 
     camera_params = []
-    frames = np.arange(anchors['id_frames'][0], anchors['id_frames'][-1])
+    frames = np.arange(anchors['id_frames'][0], anchors['id_frames'][-1] + 1)
     camera_params = []
     keys = ['id_frames', 'sim_times', 'r', 't',
             'p', 'x', 'y', 'z', 'zoom', 'extent']


### PR DESCRIPTION
The camera tools don't output the camera parameters for the last frame requested but get stuck on the second-last because there's a `+1` missing in the argument of `np.arange`. Fixed this.